### PR TITLE
Small changes

### DIFF
--- a/source/ut_annotations.pkb
+++ b/source/ut_annotations.pkb
@@ -101,7 +101,7 @@ create or replace package body ut_annotations as
 
   end get_annotations;
 
-  function get_package_annotations(a_source varchar2, a_comments tt_comment_list) return tt_annotations is
+  function get_package_annotations(a_source clob, a_comments tt_comment_list) return tt_annotations is
     l_package_comments varchar2(32767);
   begin
     l_package_comments := regexp_substr(srcstr        => a_source
@@ -116,7 +116,7 @@ create or replace package body ut_annotations as
       end;
   end;
 
-  function get_procedure_annotations(a_source varchar2, a_comments tt_comment_list) return tt_procedure_annotations is
+  function get_procedure_annotations(a_source clob, a_comments tt_comment_list) return tt_procedure_annotations is
     l_proc_comments         varchar2(32767);
     l_proc_name             t_annotation_name;
     l_annot_proc_ind        number;

--- a/source/ut_annotations.pks
+++ b/source/ut_annotations.pks
@@ -49,8 +49,11 @@ create or replace package ut_annotations as
   type typ_annotated_package is record(
      procedure_annotations  tt_procedure_annotations
     ,package_annotations    tt_annotations);
-
-
+    
+  /*
+    INTERNAL USE ONLY
+  */
+  function parse_package_annotations(a_source clob) return typ_annotated_package;
 
   /*
     function: get_package_annotations

--- a/source/ut_suite_manager.pkb
+++ b/source/ut_suite_manager.pkb
@@ -180,32 +180,11 @@ create or replace package body ut_suite_manager is
   
   begin
     -- form the single-dimension list of suites constructed from parsed packages
-    for rec in (with excl as
-                   (select /*+materialize*/
-                    t1.owner
-                   ,t1.type_name
-                     from all_types t1
-                    start with t1.owner = sys_context('userenv', 'current_schema')
-                           and t1.type_name in ('UT_SUITE_REPORTER'
-                                               ,'UT_REPORTERS_LIST'
-                                               ,'UT_OBJECTS_LIST'
-                                               ,'UT_EXECUTABLE'
-                                               ,'UT_OBJECT')
-                   
-                   connect by prior t1.owner = t1.supertype_owner
-                          and prior t1.type_name = t1.supertype_name
-                   union all
-                   select tt.owner
-                         ,tt.object_name
-                     from all_objects tt
-                    where tt.owner = sys_context('userenv', 'current_schema')
-                      and tt.object_name in ('UT_METADATA', 'UT_SUITE_MANAGER', 'UT_ASSERT', 'UT_UTILS'))
-                  select t.owner
-                        ,t.object_name
-                    from all_objects t
-                   where t.owner = a_owner_name
-                     and t.object_type in ('PACKAGE')
-                     and (t.owner, t.object_name) not in (select * from excl)) loop
+    for rec in (select t.owner
+                      ,t.object_name
+                  from all_objects t
+                 where t.owner = a_owner_name
+                   and t.object_type in ('PACKAGE')) loop
       -- parse the source of the package
       l_suite := config_package(rec.owner, rec.object_name);
     

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -10,8 +10,10 @@ set serveroutput on size unlimited format truncated
 --Global setup
 @@helpers/ut_example_tests.pks
 @@helpers/ut_example_tests.pkb
+@@helpers/check_annotation_parsing.prc
 
 --Tests to invoke
+
 @@lib/RunTest.sql ut_test/ut_test.OwnerNameInvalid.sql
 @@lib/RunTest.sql ut_test/ut_test.OwnerNameNull.sql
 @@lib/RunTest.sql ut_test/ut_test.PackageInInvalidState.sql
@@ -92,8 +94,18 @@ set serveroutput on size unlimited format truncated
 @@lib/RunTest.sql ut_utils/ut_utils.to_string.veryBigNumber.sql
 @@lib/RunTest.sql ut_utils/ut_utils.to_string.Date.sql
 @@lib/RunTest.sql ut_utils/ut_utils.to_string.Timestamp.sql
+
+
+@@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotation.sql
+@@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithMultilineComment.sql
+@@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithKeyValue.sql
+@@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationNotBeforeProcedure.sql
+@@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageAndProcedureLevelAnnotations.sql
+@@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParseComplexPackage.sql
+
 --Global cleanup
 drop package ut_example_tests;
+drop procedure check_annotation_parsing;
 
 --Finally
 @@lib/RunSummary

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -101,7 +101,9 @@ set serveroutput on size unlimited format truncated
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithKeyValue.sql
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationNotBeforeProcedure.sql
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageAndProcedureLevelAnnotations.sql
+@@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationMixedWithWrongBeforeProcedure.sql
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParseComplexPackage.sql
+
 
 --Global cleanup
 drop package ut_example_tests;

--- a/tests/helpers/check_annotation_parsing.prc
+++ b/tests/helpers/check_annotation_parsing.prc
@@ -1,0 +1,62 @@
+create or replace procedure check_annotation_parsing(a_expected ut_annotations.typ_annotated_package, a_parsing_result ut_annotations.typ_annotated_package) is
+  procedure check_annotation_params(a_msg varchar2, a_expected ut_annotations.tt_annotation_params, a_actual ut_annotations.tt_annotation_params) is
+  begin
+    ut_assert.are_equal('['||a_msg||']Check number of annotation params', a_expected.count, a_actual.count);
+    
+    if a_expected.count = a_actual.count and a_expected.count > 0 then
+      for i in 1..a_expected.count loop
+        if a_expected(i).key is not null then
+          ut_assert.are_equal('['||a_msg||'('||i||')]Check annotation param key',a_expected(i).key,a_actual(i).key);
+        else
+          ut_assert.is_null('['||a_msg||'('||i||')]Check annotation param key',a_actual(i).key);
+        end if;
+        
+        if a_expected(i).value is not null then
+          ut_assert.are_equal('['||a_msg||'('||i||')]Check annotation param value',a_expected(i).value,a_actual(i).value);
+        else
+          ut_assert.is_null('['||a_msg||'('||i||')]Check annotation param value',a_actual(i).value);
+        end if;
+      end loop;
+    end if;
+  end;
+  
+  procedure check_annotations(a_msg varchar2, a_expected ut_annotations.tt_annotations, a_actual ut_annotations.tt_annotations) is
+    l_ind varchar2(500);
+  begin
+    ut_assert.are_equal('['||a_msg||']Check number of annotations parsed',a_expected.count,a_actual.count);
+    
+    if a_expected.count = a_actual.count and a_expected.count > 0 then
+      l_ind := a_expected.first;
+      while l_ind is not null loop
+        
+        ut_assert.this('['||a_msg||']Check annotation exists', a_actual.exists(l_ind));
+        if a_actual.exists(l_ind) then
+          check_annotation_params(a_msg||'.'||l_ind,a_expected(l_ind),a_actual(l_ind));
+        end if;
+        l_ind := a_expected.next(l_ind);
+      end loop;
+    end if;
+  end;
+  
+  procedure check_procedures(a_msg varchar2,  a_expected ut_annotations.tt_procedure_annotations, a_actual ut_annotations.tt_procedure_annotations) is
+    l_ind varchar2(500);
+  begin
+    ut_assert.are_equal('['||a_msg||']Check number of procedures parsed',a_expected.count,a_actual.count);
+    
+    if a_expected.count = a_actual.count and a_expected.count > 0 then
+      l_ind := a_expected.first;
+      while l_ind is not null loop
+        
+        ut_assert.this('['||a_msg||']Check procedure exists', a_actual.exists(l_ind));
+        if a_actual.exists(l_ind) then
+          check_annotations(a_msg||'.'||l_ind,a_expected(l_ind),a_actual(l_ind));
+        end if;
+        l_ind := a_expected.next(l_ind);
+      end loop;
+    end if;
+  end;
+begin
+  check_annotations('PACKAGE',a_expected.package_annotations,a_parsing_result.package_annotations);
+  check_procedures('PROCEDURES',a_expected.procedure_annotations,a_parsing_result.procedure_annotations);
+end check_annotation_parsing;
+/

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationMixedWithWrongBeforeProcedure.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationMixedWithWrongBeforeProcedure.sql
@@ -1,0 +1,44 @@
+PROMPT Parse procedure level annotations with annotations mixed with comments
+
+--Arrange
+declare
+  l_source clob;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+
+begin
+  l_source := 'PACKAGE test_tt AS
+  -- %suite(Name of suite)
+  -- %suitepackage(all.globaltests)
+  
+  -- %ann1(Name of suite)
+  -- wrong line
+  -- %ann2(some_value)  
+  procedure foo;
+END;';
+
+--Act
+  l_parsing_result := ut_annotations.parse_package_annotations(l_source);
+  
+--Assert
+  l_ann_param := null;
+  l_ann_param.value := 'Name of suite'; 
+  l_expected.package_annotations('suite')(1) := l_ann_param;
+  
+  l_ann_param := null;
+  l_ann_param.value := 'all.globaltests';  
+  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  
+  l_ann_param := null;
+  l_ann_param.value := 'some_value';  
+  l_expected.procedure_annotations('foo')('ann2')(1) := l_ann_param;
+  
+  check_annotation_parsing(l_expected, l_parsing_result);
+  
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationNotBeforeProcedure.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationNotBeforeProcedure.sql
@@ -1,0 +1,40 @@
+PROMPT Parse package level annotations with annotations "in the air"
+
+--Arrange
+declare
+  l_source clob;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+
+begin
+  l_source := 'PACKAGE test_tt AS
+  -- %suite(Name of suite)
+  -- %suitepackage(all.globaltests)
+  
+  -- %ann1(Name of suite)
+  -- %ann2(all.globaltests)  
+  
+  procedure foo;
+END;';
+
+--Act
+  l_parsing_result := ut_annotations.parse_package_annotations(l_source);
+  
+--Assert
+  l_ann_param := null;
+  l_ann_param.value := 'Name of suite'; 
+  l_expected.package_annotations('suite')(1) := l_ann_param;
+  
+  l_ann_param := null;
+  l_ann_param.value := 'all.globaltests';  
+  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  
+  check_annotation_parsing(l_expected, l_parsing_result);
+  
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseComplexPackage.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseComplexPackage.sql
@@ -1,0 +1,63 @@
+PROMPT Parse complex package
+
+--Arrange
+declare
+  l_source clob;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+
+begin
+  l_source := 'PACKAGE test_tt AS
+  -- %suite(Name of suite)
+  -- %suitepackage(all.globaltests)
+  
+  --%test
+  procedure foo;
+  
+  
+  --%setup
+  procedure foo2;
+  
+  --test comment
+  -- wrong comment
+  
+  
+  /*
+  describtion of the procedure
+  */
+  --%setup(key=testval)
+  PROCEDURE foo3(a_value number default null);
+  
+  function foo4(a_val number default null
+    , a_par varchar2 default := ''asdf'');
+END;';
+
+--Act
+  l_parsing_result := ut_annotations.parse_package_annotations(l_source);
+  
+--Assert
+  l_ann_param := null;
+  l_ann_param.value := 'Name of suite'; 
+  l_expected.package_annotations('suite')(1) := l_ann_param;
+  
+  l_ann_param := null;
+  l_ann_param.value := 'all.globaltests';  
+  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  
+  l_expected.procedure_annotations('foo')('test') := cast( null as ut_annotations.tt_annotation_params);
+  l_expected.procedure_annotations('foo2')('setup') := cast( null as ut_annotations.tt_annotation_params);
+  
+  l_ann_param := null;
+  l_ann_param.key := 'key'; 
+  l_ann_param.value := 'testval'; 
+  l_expected.procedure_annotations('foo3')('setup')(1) := l_ann_param;
+  
+  check_annotation_parsing(l_expected, l_parsing_result);
+  
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageAndProcedureLevelAnnotations.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageAndProcedureLevelAnnotations.sql
@@ -1,0 +1,40 @@
+PROMPT Parse package level annotations
+
+--Arrange
+declare
+  l_source clob;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+
+begin
+  l_source := 'PACKAGE test_tt AS
+  -- %suite(Name of suite)
+  -- %suitepackage(all.globaltests)
+  
+  --%test
+  procedure foo;
+END;';
+
+--Act
+  l_parsing_result := ut_annotations.parse_package_annotations(l_source);
+  
+--Assert
+  l_ann_param := null;
+  l_ann_param.value := 'Name of suite'; 
+  l_expected.package_annotations('suite')(1) := l_ann_param;
+  
+  l_ann_param := null;
+  l_ann_param.value := 'all.globaltests';  
+  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  
+  l_expected.procedure_annotations('foo')('test') := cast( null as ut_annotations.tt_annotation_params);
+  
+  check_annotation_parsing(l_expected, l_parsing_result);
+  
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotation.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotation.sql
@@ -1,0 +1,37 @@
+PROMPT Parse package level annotations
+
+--Arrange
+declare
+  l_source clob;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+
+begin
+  l_source := 'PACKAGE test_tt AS
+  -- %suite(Name of suite)
+  -- %suitepackage(all.globaltests)
+  
+  procedure foo;
+END;';
+
+--Act
+  l_parsing_result := ut_annotations.parse_package_annotations(l_source);
+  
+--Assert
+  l_ann_param := null;
+  l_ann_param.value := 'Name of suite'; 
+  l_expected.package_annotations('suite')(1) := l_ann_param;
+  
+  l_ann_param := null;
+  l_ann_param.value := 'all.globaltests';  
+  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  
+  check_annotation_parsing(l_expected, l_parsing_result);
+  
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithKeyValue.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithKeyValue.sql
@@ -1,0 +1,44 @@
+PROMPT Parse package level annotations
+
+--Arrange
+declare
+  l_source clob;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+
+begin
+  l_source := 'PACKAGE test_tt AS
+  -- %suite(name = Name of suite)
+  -- %suitepackage(key=all.globaltests,key2=foo)
+  
+  procedure foo;
+END;';
+
+--Act
+  l_parsing_result := ut_annotations.parse_package_annotations(l_source);
+  
+--Assert
+  l_ann_param := null;
+  l_ann_param.key := 'name'; 
+  l_ann_param.value := 'Name of suite'; 
+  l_expected.package_annotations('suite')(1) := l_ann_param;
+  
+  l_ann_param := null;
+  l_ann_param.key := 'key'; 
+  l_ann_param.value := 'all.globaltests';  
+  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  
+  l_ann_param := null;
+  l_ann_param.key := 'key2'; 
+  l_ann_param.value := 'foo';  
+  l_expected.package_annotations('suitepackage')(2) := l_ann_param;
+  
+  check_annotation_parsing(l_expected, l_parsing_result);
+  
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithMultilineComment.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithMultilineComment.sql
@@ -1,0 +1,41 @@
+PROMPT Parse package level annotations with multiline comment
+
+--Arrange
+declare
+  l_source clob;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+
+begin
+  l_source := 'PACKAGE test_tt AS
+  /*
+  Some comment
+  -- inlined
+  */
+  -- %suite(Name of suite)
+  -- %suitepackage(all.globaltests)
+  
+  procedure foo;
+END;';
+
+--Act
+  l_parsing_result := ut_annotations.parse_package_annotations(l_source);
+  
+--Assert
+  l_ann_param := null;
+  l_ann_param.value := 'Name of suite'; 
+  l_expected.package_annotations('suite')(1) := l_ann_param;
+  
+  l_ann_param := null;
+  l_ann_param.value := 'all.globaltests';  
+  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  
+  check_annotation_parsing(l_expected, l_parsing_result);
+  
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/


### PR DESCRIPTION
added function parse_package_annotations(a_source clob) return typ_annotated_package call to specification, marked as internal use only
made source view determination "lazy" on first execution
fixed bug that `get_procedure_annotations` accepted varchar instead of clob as argument